### PR TITLE
Add ID prop to clipper-upload

### DIFF
--- a/src/components/clipper-upload.vue
+++ b/src/components/clipper-upload.vue
@@ -9,6 +9,7 @@
     <input
       type="file"
       class="upload"
+      :id="id"
       :accept="accept"
       style="display:none"
       @change="upload($event)"
@@ -31,6 +32,10 @@ export default {
       default: true
     },
     value: {
+      type: String,
+      default: ''
+    },
+    id: {
       type: String,
       default: ''
     },


### PR DESCRIPTION
# Changes
* Add an optional ID prop to the clipper-upload component

# Reason
This way you can reference the input from labels, in my scenario I want to be able to click on my label that refers to the matching input id.