### PR TITLE
Fix support with Dart Sass 2.0.0

### DIFF
--- a/src/components/clipper-basic.vue
+++ b/src/components/clipper-basic.vue
@@ -654,24 +654,24 @@ $grid-width: 1px; //dive 2
   top: 0;
   left: 0;
   border-width: 0 $grid-width $grid-width 0;
-  transform: translate($grid-width/2,$grid-width/2);
+  transform: translate(math.div($grid-width, 2), math.div($grid-width, 2));
 }
 .vuejs-clipper-basic__grid-item:nth-child(2) {
   top: 0;
   right: 0;
   border-width: 0 0 $grid-width 0;
-  transform: translate(-$grid-width/2,$grid-width/2);
+  transform: translate(math.div(-$grid-width, 2), math.div($grid-width, 2));
 }
 .vuejs-clipper-basic__grid-item:nth-child(3) {
   bottom: 0;
   left: 0;
   border-width: 0 $grid-width 0 0;
-  transform: translate($grid-width/2,-$grid-width/2);
+  transform: translate(math.div($grid-width, 2), math.div(-$grid-width, 2));
 }
 .vuejs-clipper-basic__grid-item:nth-child(4) {
   bottom: 0;
   right: 0;
   border-width: 0;
-  transform: translate(-$grid-width/2,-$grid-width/2);
+  transform: translate(math.div(-$grid-width, 2), math.div(-$grid-width, 2));
 }
 </style>

--- a/src/components/clipper-fixed.vue
+++ b/src/components/clipper-fixed.vue
@@ -461,24 +461,24 @@ $grid-width: 1px;
   top: 0;
   left: 0;
   border-width: 0 $grid-width $grid-width 0;
-  transform: translate($grid-width/2, $grid-width/2);
+  transform: translate(math.div($grid-width, 2), math.div($grid-width, 2));
 }
 .vuejs-clipper-fixed__grid-item:nth-child(2) {
   top: 0;
   right: 0;
   border-width: 0 0 $grid-width 0;
-  transform: translate(-$grid-width/2, $grid-width/2);
+  transform: translate(math.div(-$grid-width, 2), math.div($grid-width, 2));
 }
 .vuejs-clipper-fixed__grid-item:nth-child(3) {
   bottom: 0;
   left: 0;
   border-width: 0 $grid-width 0 0;
-  transform: translate($grid-width/2, -$grid-width/2);
+  transform: translate(math.div($grid-width, 2), math.div(-$grid-width, 2));
 }
 .vuejs-clipper-fixed__grid-item:nth-child(4) {
   bottom: 0;
   right: 0;
   border-width: 0;
-  transform: translate(-$grid-width/2, -$grid-width/2);
+  transform: translate(math.div(-$grid-width, 2), math.div(-$grid-width, 2));
 }
 </style>


### PR DESCRIPTION
Using / for division is deprecated and will be removed in Dart Sass 2.0.0

This fix issue #114